### PR TITLE
Rename entity to entity_id for AppDaemon 4.2.0

### DIFF
--- a/apps/people_tracker/people_tracker.py
+++ b/apps/people_tracker/people_tracker.py
@@ -67,11 +67,11 @@ class PeopleTracker(hass.Hass):
         self.handles = []
 
         for entity_id in self.entities:
-            handle = self.listen_state(self.track_person, entity = entity_id)
+            handle = self.listen_state(self.track_person, entity_id = entity_id)
             self.handles.append(handle)
 
         if self.guest_entity_id:
-            handle = self.listen_state(self.track_guests, entity = self.guest_entity_id)
+            handle = self.listen_state(self.track_guests, entity_id = self.guest_entity_id)
             self.handles.append(handle)
 
         #Populate people on startup.


### PR DESCRIPTION
Issue #4

Breaking change in AppDaemon 4.2.0 (released Jan 3, 2022)
- Changed set_state and listen_state to support entity_id and not entity, to standardise use across api calls

Two instances of listen_state used a keyword argument for entity, now changed to entity_id.
Without this change, the count was initialised correctly at startup, but the change listener was not filtering, and picking up other entities to add them to the count.